### PR TITLE
[bug] xhr.onerror (if error returned by parse server)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules
+Parse-SDK-JS-master/lib


### PR DESCRIPTION
When on error, responseText set to null if an error was received or no data was returned.

Referred : http://docs.appcelerator.com/platform/latest/#!/api/Titanium.Network.HTTPClient-property-responseText

Thank you so much to you.
